### PR TITLE
Rework ghr alias to include gh run subcommands

### DIFF
--- a/zsh/compat_fish/gh.zsh
+++ b/zsh/compat_fish/gh.zsh
@@ -74,3 +74,13 @@ abbr ghw 'gh repo view --web'
 abbr ghb 'gh repo view --branch'
 abbr ghwb 'gh repo view --web --branch'
 abbr ghv 'gh repo view'
+
+# gh run subcommands
+abbr ghr 'gh run'
+abbr ghrl 'gh run list'
+abbr ghrv 'gh run view'
+abbr ghrr 'gh run rerun'
+abbr ghrc 'gh run cancel'
+abbr ghrd 'gh run delete'
+abbr ghrw 'gh run watch'
+abbr ghrdl 'gh run download'

--- a/zsh/compat_fish/gh.zsh
+++ b/zsh/compat_fish/gh.zsh
@@ -5,7 +5,6 @@
 # PRN prune unnecessary aliases => I clearly added the kitchen sink
 
 # live docs!
-abbr ghr 'gh reference'
 abbr ghh 'gh reference'
 
 # gh issue


### PR DESCRIPTION
test drive copilot workspace - ask it to rework-ghr - mostly correct but missing removal of `ghr` => `gh reference` which is now unused.

Related to #1

Reworks the `ghr` alias in `zsh/compat_fish/gh.zsh` to expand into `gh run` and its subcommands, enhancing the command-line interface for GitHub CLI users.

- **Introduces new aliases for `gh run` subcommands**: Adds aliases `ghrl` for `gh run list`, `ghrv` for `gh run view`, `ghrr` for `gh run rerun`, `ghrc` for `gh run cancel`, `ghrd` for `gh run delete`, `ghrw` for `gh run watch`, and `ghrdl` for `gh run download`. This allows for quicker and more intuitive access to common `gh run` operations directly from the terminal.
- **Maintains existing functionality**: The update preserves the existing aliases and commands for other `gh` functionalities, ensuring that the addition of new `gh run` subcommand aliases does not disrupt the current user experience.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/g0t4/dotfiles/issues/1?shareId=1e848e38-aca3-42a2-b8b6-5ac7e8af10fa).